### PR TITLE
Update Cadence (statsd client) to version 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ openssl = "0.7"
 router = "0.2"
 rustc-serialize = "0.3"
 
-cadence = { version = "0.8.0", optional = true }
+cadence = { version = "0.11.0", optional = true }
 prometheus = { version = "0.2", optional = true }
 
 slack-hook = { version = "0.2", optional = true }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 #[cfg(feature = "stats-statsd")]
 use cadence::prelude::*;
 #[cfg(feature = "stats-statsd")]
-use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
+use cadence::{StatsdClient, DEFAULT_PORT};
 
 #[cfg(feature = "stats-prometheus")]
 lazy_static! {
@@ -57,8 +57,8 @@ lazy_static! {
 
 #[cfg(feature = "stats-statsd")]
 lazy_static! {
-    static ref GRAPIHTE_CLIENT: StatsdClient<UdpMetricSink> =
-        StatsdClient::<UdpMetricSink>::from_udp_host("kafka.proxy",
+    static ref GRAPIHTE_CLIENT: StatsdClient =
+        StatsdClient::from_udp_host("kafka.proxy",
             (Ipv4Addr::from_str(&env::var("GRAPHITE_HOST").unwrap()).unwrap(), DEFAULT_PORT)).unwrap();
 }
 


### PR DESCRIPTION
Update to the latest version of Cadence (0.11.0). This upgrade involves a breaking change (the generic parameter was removed from `StatsdClient`) hence this PR. Thanks!